### PR TITLE
qrライブラリの更新とgo.modの追加

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/MizukiSonoko/qrcat
+module github.com/yuya-takeyama/qrcat
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/MizukiSonoko/qrcat
+
+go 1.12
+
+require (
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
+	github.com/yuya-takeyama/argf v0.0.0-20150217044922-3ff699b4b958
+	rsc.io/qr v0.2.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/yuya-takeyama/argf v0.0.0-20150217044922-3ff699b4b958 h1:Me/Pr07yvxPSqrFMOENfapb5rPBy9XMHqtk/cJXQucg=
+github.com/yuya-takeyama/argf v0.0.0-20150217044922-3ff699b4b958/go.mod h1:2ofZVA+WPX1lImOQjRpHBEn+vpk6FHYSwr3PyyiTCC4=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
+rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=

--- a/main.go
+++ b/main.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"os"
 
-	"code.google.com/p/rsc/qr"
 	"github.com/mgutz/ansi"
 	"github.com/yuya-takeyama/argf"
+	"rsc.io/qr"
 )
 
 type Format int


### PR DESCRIPTION
突然のQR失礼します。

## Feature
- "code.google.com/p/rsc/qr" が以下のようなエラーを出してしまうので "rsc.io/qr"を使うように変更
```
build github.com/yuya-takeyama/qrcat: cannot load code.google.com/p/rsc/qr: cannot find module providing package code.google.com/p/rsc/qr
```
- go.modを導入し依存ライブラリのバージョン管理を行うように変更

## References
- https://github.com/rsc/qr
- https://qiita.com/pokeh/items/139d0f1fe56e358ba597
